### PR TITLE
docs: add missing cream theme to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ main()
 
 ## Tmux themes
 
-9 themes: `cobalt` (default), `green`, `blue`, `purple`, `orange`, `red`, `nord`, `everforest`, `gruvbox`.
+10 themes: `cobalt` (default), `green`, `blue`, `purple`, `orange`, `red`, `nord`, `everforest`, `gruvbox`, `cream`.
 
 Auto-theme logic in `apply-theme-hook.sh`:
 - Session name `*dev*`, `*code*`, `*claude*` → green


### PR DESCRIPTION
## Summary
- `themes.sh` defines 10 tmux themes but CLAUDE.md documented only 9, omitting `cream`
- Updated theme count from 9 → 10 and added `cream` to the list

## Test plan
- [ ] Verify `data/themes.sh` contains the `cream` case (line 125)
- [ ] Verify CLAUDE.md now lists all 10 themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)