### PR TITLE
fix: portability — non-interactive mode, auto-install modern tools, guard config alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,9 @@ main()
 | `zsc` command | bash invocation |
 |---|---|
 | `zsc install` | `install.sh` |
+| `zsc install --yes` | `install.sh --yes` |
 | `zsc update` | `install.sh --update` |
+| `zsc update --yes` | `install.sh --update --yes` |
 | `zsc update eza` | `install.sh --update --only eza` |
 | `zsc status` | `install.sh --status` |
 | `zsc theme nord` | `bash ~/.tmux/themes.sh nord <session>` |
@@ -110,6 +112,7 @@ Auto-theme logic in `apply-theme-hook.sh`:
 node bin/cli.js help
 node bin/cli.js update badcomponent   # should error with valid list
 node bin/cli.js theme badtheme        # should error with valid list
+node bin/cli.js install --yes         # should pass --yes to install.sh
 
 # Dry-run status check
 bash install.sh --status

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -37,6 +37,9 @@ Commands:
   status                    Show installed versions and health check
   help                      Show this help
 
+Options:
+  --yes, -y                 Non-interactive: auto-confirm all prompts (CI/Docker)
+
 Components (for update):
   eza  tmux  starship  fonts  zshrc  omz  plugins  statusline  tools
 
@@ -45,6 +48,7 @@ Themes (for theme):
 
 Examples:
   zsc install
+  zsc install --yes         # no prompts — for scripts/Dockerfiles
   zsc update
   zsc update eza
   zsc theme nord
@@ -147,9 +151,9 @@ function resolveTmuxSession(explicitSession) {
 // Subcommand handlers
 // ---------------------------------------------------------------------------
 
-/** zsc install → install.sh (no extra args) */
-function cmdInstall() {
-  runInstallScript([]);
+/** zsc install [--yes] → install.sh [--yes] */
+function cmdInstall(yes) {
+  runInstallScript(yes ? ['--yes'] : []);
 }
 
 /**
@@ -157,7 +161,7 @@ function cmdInstall() {
  *   → install.sh --update
  *   → install.sh --update --only <component>
  */
-function cmdUpdate(component) {
+function cmdUpdate(component, yes) {
   if (component !== undefined && !COMPONENTS.includes(component)) {
     console.error(`Error: unknown component "${component}".`);
     console.error(`Valid components: ${COMPONENTS.join(', ')}`);
@@ -165,6 +169,7 @@ function cmdUpdate(component) {
   }
 
   const args = ['--update'];
+  if (yes) args.push('--yes');
   if (component) {
     args.push('--only', component);
   }
@@ -232,14 +237,18 @@ function cmdHelp() {
 
 const [, , subcommand, ...rest] = process.argv;
 
+// Extract --yes / -y flag from remaining args
+const yesFlag = rest.includes('--yes') || rest.includes('-y');
+const filteredRest = rest.filter(a => a !== '--yes' && a !== '-y');
+
 switch (subcommand) {
   case 'install':
-    cmdInstall();
+    cmdInstall(yesFlag);
     break;
 
   case 'update':
-    // rest[0] is the optional component name
-    cmdUpdate(rest[0]);
+    // filteredRest[0] is the optional component name
+    cmdUpdate(filteredRest[0], yesFlag);
     break;
 
   case 'theme':

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ fi
 # Global variables
 UPDATE_MODE=false
 VERBOSE=false
+YES_MODE=false      # set by --yes / -y: auto-confirm all prompts
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ONLY_COMPONENT=""   # set by --only <component>
 STATUS_MODE=false   # set by --status
@@ -34,13 +35,15 @@ Automatic installation of Zsh + Starship + Nerd Fonts
 
 OPTIONS:
     -u, --update        Update mode: update already installed components
+    -y, --yes           Non-interactive: auto-confirm all prompts (CI/Docker)
     -v, --verbose       Verbose output
     -h, --help          Show this message
 
 EXAMPLES:
     ./install.sh                # Normal installation
     ./install.sh --update       # Update all components
-    ./install.sh -u -v          # Update with verbose output
+    ./install.sh -u -y          # Update non-interactively (no prompts)
+    ./install.sh -y             # Fresh install, auto-confirm everything
 
 EOF
 }
@@ -50,6 +53,10 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         -u|--update)
             UPDATE_MODE=true
+            shift
+            ;;
+        -y|--yes)
+            YES_MODE=true
             shift
             ;;
         -v|--verbose)
@@ -518,16 +525,30 @@ EOF
 
 # Install modern tools (optional)
 install_modern_tools() {
-    echo -e "\n🛠️  Installing modern tools (optional)..."
+    echo -e "\n🛠️  Installing modern tools (bat, ripgrep, fd, zoxide, fzf)..."
 
-    read -p "Do you want to install bat, ripgrep, fd, zoxide? (y/N) " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[YySs]$ ]]; then
-        if [ "$OS" = "fedora" ]; then
+    local DO_INSTALL=false
+
+    if [ "$YES_MODE" = true ] || [ "$UPDATE_MODE" = true ]; then
+        DO_INSTALL=true
+    else
+        read -p "Install bat, ripgrep, fd, zoxide, fzf? These power the shell aliases. (Y/n) " -n 1 -r
+        echo
+        # Default to yes: empty reply or y/Y/s/S
+        if [[ -z "$REPLY" || "$REPLY" =~ ^[YySs]$ ]]; then
+            DO_INSTALL=true
+        fi
+    fi
+
+    if [ "$DO_INSTALL" = true ]; then
+        if [ "$OS" = "fedora" ] || [ "$OS" = "rhel" ] || [ "$OS" = "centos" ]; then
             sudo dnf install -y bat ripgrep fd-find zoxide fzf
         elif [ "$OS" = "ubuntu" ] || [ "$OS" = "debian" ]; then
             sudo apt install -y bat ripgrep fd-find fzf zoxide
         fi
+        echo "✓ Modern tools installed"
+    else
+        echo "⊘ Modern tools skipped (aliases for bat/rg/fd/z won't be active)"
     fi
 }
 
@@ -735,8 +756,10 @@ fi
 # Bun completions (if installed)
 [ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
 
-# Alias for dotfiles management (Bare Git Repository)
-alias config='/usr/bin/git --git-dir=$HOME/.cfg/ --work-tree=$HOME'
+# Alias for dotfiles management (Bare Git Repository) — only if ~/.cfg exists
+if [ -d "$HOME/.cfg" ]; then
+    alias config='/usr/bin/git --git-dir=$HOME/.cfg/ --work-tree=$HOME'
+fi
 
 # Disable non-essential traffic and telemetry
 export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
@@ -843,13 +866,15 @@ EOF
         CHANGES_MADE=true
     fi
 
-    # Check dotfiles bare git alias
-    if ! grep -q "alias config=" "$ZSHRC"; then
-        echo "  + Adding dotfiles alias (config)"
+    # Check dotfiles bare git alias — only add if ~/.cfg exists
+    if [ -d "$HOME/.cfg" ] && ! grep -q "alias config=" "$ZSHRC"; then
+        echo "  + Adding dotfiles alias (config) — ~/.cfg detected"
         cat >> "$ZSHRC" << 'EOF'
 
-# Alias per gestire i dotfiles (Bare Git Repository)
-alias config='/usr/bin/git --git-dir=$HOME/.cfg/ --work-tree=$HOME'
+# Alias for dotfiles management (Bare Git Repository) — only if ~/.cfg exists
+if [ -d "$HOME/.cfg" ]; then
+    alias config='/usr/bin/git --git-dir=$HOME/.cfg/ --work-tree=$HOME'
+fi
 EOF
         CHANGES_MADE=true
     fi
@@ -1041,13 +1066,23 @@ EOF
 change_shell_to_zsh() {
     echo -e "\n🐚 Changing default shell to Zsh..."
 
-    if [ "$SHELL" = "$(which zsh)" ]; then
+    local ZSH_PATH
+    ZSH_PATH="$(which zsh)"
+
+    # Check both $SHELL and getent (handles cases where SHELL env isn't updated yet)
+    local CURRENT_SHELL
+    CURRENT_SHELL=$(getent passwd "$USER" 2>/dev/null | cut -d: -f7 || echo "$SHELL")
+
+    if [ "$CURRENT_SHELL" = "$ZSH_PATH" ] || [ "$SHELL" = "$ZSH_PATH" ]; then
         echo "✓ Zsh already default shell"
+    elif [ "$YES_MODE" = true ] || [ "$UPDATE_MODE" = true ]; then
+        chsh -s "$ZSH_PATH"
+        echo "✓ Shell changed to Zsh (requires logout)"
     else
-        read -p "Do you want to set Zsh as default shell? (y/N) " -n 1 -r
+        read -p "Do you want to set Zsh as default shell? (Y/n) " -n 1 -r
         echo
-        if [[ $REPLY =~ ^[YySs]$ ]]; then
-            chsh -s "$(which zsh)"
+        if [[ -z "$REPLY" || "$REPLY" =~ ^[YySs]$ ]]; then
+            chsh -s "$ZSH_PATH"
             echo "✓ Shell changed to Zsh (requires logout)"
         fi
     fi
@@ -1289,19 +1324,19 @@ install_tmux() {
         if [ -f "$HOME/.tmux.conf" ]; then
             if ! diff -q "$SCRIPT_DIR/data/tmux.conf" "$HOME/.tmux.conf" &>/dev/null; then
                 echo "⚠️  .tmux.conf differs from repository version"
-                if [ "$UPDATE_MODE" = true ]; then
+                if [ "$UPDATE_MODE" = true ] || [ "$YES_MODE" = true ]; then
                     BACKUP="$HOME/.tmux.conf.backup.$(date +%Y%m%d_%H%M%S)"
-                    cp "$HOME/.tmux.conf" "$BACKUP"
-                    cp "$SCRIPT_DIR/data/tmux.conf" "$HOME/.tmux.conf"
+                    cp -f "$HOME/.tmux.conf" "$BACKUP"
+                    cp -f "$SCRIPT_DIR/data/tmux.conf" "$HOME/.tmux.conf"
                     patch_tmux_conf "$HOME/.tmux.conf"
                     echo "✓ .tmux.conf updated (backup: $BACKUP)"
                 else
-                    read -p "Apply tmux config? Current config will be backed up. (y/N) " -n 1 -r
+                    read -p "Apply tmux config? Current config will be backed up. (Y/n) " -n 1 -r
                     echo
-                    if [[ $REPLY =~ ^[YySs]$ ]]; then
+                    if [[ -z "$REPLY" || "$REPLY" =~ ^[YySs]$ ]]; then
                         BACKUP="$HOME/.tmux.conf.backup.$(date +%Y%m%d_%H%M%S)"
-                        cp "$HOME/.tmux.conf" "$BACKUP"
-                        cp "$SCRIPT_DIR/data/tmux.conf" "$HOME/.tmux.conf"
+                        cp -f "$HOME/.tmux.conf" "$BACKUP"
+                        cp -f "$SCRIPT_DIR/data/tmux.conf" "$HOME/.tmux.conf"
                         patch_tmux_conf "$HOME/.tmux.conf"
                         echo "✓ .tmux.conf updated (backup: $BACKUP)"
                     else


### PR DESCRIPTION
## Summary

- **`--yes` / `-y` flag** added to both `install.sh` and `zsc` CLI — auto-confirms all prompts, enabling CI/Docker/scripted use: `zsc install --yes`
- **`install_modern_tools`** now defaults to Y and auto-installs in `--update`/`--yes` mode — `bat`, `ripgrep`, `fd`, `zoxide`, `fzf` were silently skipped on fresh installs when users pressed Enter
- **`change_shell_to_zsh`** uses `getent` for reliable shell detection; auto-changes in non-interactive modes; default prompt flipped to Y
- **`config` dotfiles alias** is now guarded — only written to `.zshrc` when `~/.cfg` exists, avoiding confusion on machines without the bare git dotfiles repo
- **`tmux.conf` overwrite** respects `--yes` mode; `cp -f` prevents interactive alias hangs

## Root causes fixed

The main reasons the config didn't work portably on other machines:

1. Modern tools (zoxide/bat/rg/fd) were default-skipped → `z`, `bat`, `rg`, `fd` aliases did nothing
2. `config` alias always injected → confusion on every machine without `~/.cfg`
3. No way to run non-interactively → blocked in Docker/CI/scripted setups
4. Shell change prompt defaulted to N → users stayed on bash

## Test plan

- [ ] `node bin/cli.js help` — shows `--yes` in Options section
- [ ] `node bin/cli.js update badcomponent` — errors with valid list
- [ ] `node bin/cli.js theme badtheme` — errors with valid list
- [ ] `bash install.sh --status` — dry-run check
- [ ] `bash install.sh --yes` on a fresh machine — no prompts, installs everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)